### PR TITLE
Upgrade various deps and plugin deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ local.properties
 .classpath
 .settings/
 .loadpath
+*.iml
+.idea
 
 # External tool builders
 .externalToolBuilders/

--- a/TestE2ETest/pom.xml
+++ b/TestE2ETest/pom.xml
@@ -215,7 +215,7 @@
                     <plugin>
                         <groupId>org.codehaus.cargo</groupId>
                         <artifactId>cargo-maven2-plugin</artifactId>
-                        <version>1.4.7</version>
+                        <version>1.4.16</version>
                         <executions>
                             <execution>
                                 <id>start-container</id>

--- a/TestE2ETest/pom.xml
+++ b/TestE2ETest/pom.xml
@@ -54,7 +54,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
-                        <version>2.8</version>
+                        <version>2.10</version>
                         <executions>
                             <!--
                                     Copy all sources with the same groupid as this project to the output folder 

--- a/TestE2ETest/pom.xml
+++ b/TestE2ETest/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>TestE2ETest</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <jetty.version>7.6.14.v20131031</jetty.version>
+        <jetty.version>8.1.16.v20140903</jetty.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <skipTests>true</skipTests>

--- a/TestE2ETest/pom.xml
+++ b/TestE2ETest/pom.xml
@@ -181,7 +181,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.6.4.201312101107</version>
+                        <version>0.7.5.201505241946</version>
                         <executions>
                             <!--
                                 Prepares the property pointing to the JaCoCo runtime agent which
@@ -271,7 +271,7 @@
                     <plugin>
                         <groupId>org.mortbay.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
-                        <version>8.1.14.v20131031</version>
+                        <version>8.1.16.v20140903</version>
                         <executions>
                             <execution>
                                 <id>start-jetty</id>
@@ -325,7 +325,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.2.1</version>
+                        <version>1.4.0</version>
                         <executions>
                             <execution>
                                 <phase>post-integration-test</phase>

--- a/TestE2ETest/pom.xml
+++ b/TestE2ETest/pom.xml
@@ -357,12 +357,12 @@
         <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>2.3.0</version>
+            <version>2.6.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/TestE2ETest/pom.xml
+++ b/TestE2ETest/pom.xml
@@ -351,7 +351,7 @@
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
-            <version>0.6.4.201312101107</version>
+            <version>0.7.5.201505241946</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/TestE2ETest/pom.xml
+++ b/TestE2ETest/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>TestE2ETest</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <jetty.version>8.1.16.v20140903</jetty.version>
+        <jetty.version>8.1.17.v20150415</jetty.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <skipTests>true</skipTests>
@@ -269,9 +269,9 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.mortbay.jetty</groupId>
+                        <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
-                        <version>8.1.16.v20140903</version>
+                        <version>8.1.17.v20150415</version>
                         <executions>
                             <execution>
                                 <id>start-jetty</id>

--- a/TestE2ETest/pom.xml
+++ b/TestE2ETest/pom.xml
@@ -100,17 +100,17 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <version>1.7</version>
+                        <version>1.8</version>
                         <dependencies>
                             <dependency>
                                 <groupId>org.jacoco</groupId>
                                 <artifactId>org.jacoco.ant</artifactId>
-                                <version>0.6.4.201312101107</version>
+                                <version>0.7.5.201505241946</version>
                             </dependency>
                             <dependency>
                                 <groupId>ant-contrib</groupId>
                                 <artifactId>ant-contrib</artifactId>
-                                <version>20020829</version>
+                                <version>1.0b3</version>
                             </dependency>
                         </dependencies>
                         <executions>

--- a/TestE2ETest/pom.xml
+++ b/TestE2ETest/pom.xml
@@ -26,7 +26,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.16</version>
+                        <version>2.19</version>
                         <executions>
                             <execution>
                                 <id>integration-tests</id>


### PR DESCRIPTION
I fixed up quite a bit. Exceptions:

1. Spring's not upgraded to 4.x (the app is incompatible for some reason).
2. Jetty is paused at 8.x ... I think Cargo is incompatible with 9.x for the moment.